### PR TITLE
Add support for changes to internal Docker networking.

### DIFF
--- a/manage
+++ b/manage
@@ -51,7 +51,11 @@ exportEnvironment() {
   export MEDIATOR_AGENT_HTTP_IN_PORT=3000
 
   if [ -z "${PWD_HOST_FQDN}" ]; then
-      DOCKERHOST=`docker run --rm --net=host eclipse/che-ip`
+     if [[ $(uname) == "Linux" ]] ; then
+        DOCKERHOST=`docker run --rm --net=host eclipse/che-ip`
+      else
+        DOCKERHOST=host.docker.internal
+      fi
       export ENV=local
       export MEDIATOR_ENDPOINT_URL=http://${DOCKERHOST}:${MEDIATOR_AGENT_HTTP_IN_PORT}
   else
@@ -118,7 +122,7 @@ function logs() {
     while getopts ":f-:" FLAG; do
       case $FLAG in
         f ) local _force=1 ;;
-        - ) 
+        - )
             case ${OPTARG} in
                 "no-tail"*) no_tail=1
               ;;
@@ -160,7 +164,7 @@ start|up)
       docker-compose up -d mediator db ${DEMO_CONTROLLER}
   fi
   logs
-  echo "Run './manage logs' for logs" 
+  echo "Run './manage logs' for logs"
   ;;
 logs)
   exportEnvironment "$@"


### PR DESCRIPTION
- Networking changes introduced in Docker 4.1.x and forward on Windows and MAC stop the direct use of the internal docker host IP returned by the `docker run --rm --net=host eclipse/che-ip` process. On Windows and MAC `host.docker.internal` needs to be used for internal connections between containers on separate docker networks.
- `host.docker.internal` has been available on Windows and Mac since Docker Engine version 18.03 (March 2018). Support for `host.docker.internal` on Linux was introduced in version 20.10.0 (2020-12-08), but it does not run out of the box yet (as of Docker Engine 20.10.11 (2021-11-17)). You need to add `--add-host=host.docker.internal:host-gateway` to the `docker run` command in order for it to work.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>