### PR TITLE
Centralize docker host IP script.

### DIFF
--- a/manage
+++ b/manage
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 export MSYS_NO_PATHCONV=1
-
+# getDockerHost; for details refer to https://github.com/bcgov/DITP-DevOps/tree/main/code/snippets#getdockerhost
+. /dev/stdin <<<"$(cat <(curl -s --raw https://raw.githubusercontent.com/bcgov/DITP-DevOps/main/code/snippets/getDockerHost))"
 set -e
 
 SCRIPT_HOME="$(cd "$(dirname "$0")" && pwd)"
@@ -51,11 +52,7 @@ exportEnvironment() {
   export MEDIATOR_AGENT_HTTP_IN_PORT=3000
 
   if [ -z "${PWD_HOST_FQDN}" ]; then
-     if [[ $(uname) == "Linux" ]] ; then
-        DOCKERHOST=`docker run --rm --net=host eclipse/che-ip`
-      else
-        DOCKERHOST=host.docker.internal
-      fi
+      export DOCKERHOST=$(getDockerHost)
       export ENV=local
       export MEDIATOR_ENDPOINT_URL=http://${DOCKERHOST}:${MEDIATOR_AGENT_HTTP_IN_PORT}
   else


### PR DESCRIPTION
- This is an update to the previous commit to update the support for Docker networking.  The `getDockerHost` has been pulled out and placed in a central location where it can be updated as needed rather than having to update dozens of scripts the next time there is a change.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>