### PR TITLE
Upgrade to aca-py v0.8.0

### DIFF
--- a/acapy/Dockerfile.acapy
+++ b/acapy/Dockerfile.acapy
@@ -1,14 +1,6 @@
-FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-indy-1.16.0-0.8.0-rc0
+FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-indy-1.16.0-0.8.0
 
 USER root
-
-# The root group needs access the directories under $HOME/.indy_client for
-# the container to function in OpenShift. Also ensure the permissions on 
-# python 'site-packages' folder are set correctly.
-
-RUN chown -R $user:root $HOME/.indy_client $HOME/.aries_cloudagent \
-    && chmod -R ug+rw $HOME/log $HOME/ledger $HOME/.aries_cloudagent $HOME/.cache $HOME/.indy-cli $HOME/.indy_client \
-    && chmod +rx $(python -m site --user-site)
 
 RUN mkdir -p /acapy-mediator
 WORKDIR /acapy-mediator


### PR DESCRIPTION
- Latest images deal with the folder ownership and permissions.