### PR TITLE
chore: update docs on how to supply a URL

### DIFF
--- a/afj/README.md
+++ b/afj/README.md
@@ -5,8 +5,8 @@ This runs the [AFJ](https://github.com/hyperledger/aries-framework-javascript) i
 # Setup and Run
 
 This repo comes with a [.devContainer](../.devcontainer) that will allow you to build and run AFJ based src. It's added because AFJ requries some Indy libraries that can be a hastel to build. All the steps below work from the devContainer. The resulting AFJ mediator image will be placed on your local machine - no inside the devcontainer.
- 
-You're not meant to run production work load with `ts-node` so this project tries to get you off on the right foot by using `gulp` to orcestrate the build, which will transpile `.ts` to `.js`. 
+
+You're not meant to run production work load with `ts-node` so this project tries to get you off on the right foot by using `gulp` to orcestrate the build, which will transpile `.ts` to `.js`.
 
 ## Build
 
@@ -28,10 +28,10 @@ Build your docker image. This will copy in the source as needed and do a few oth
 docker build . --tag afj-mediator
 ```
 
-Next, you can open a new terminal window (not one inside of the devcontainer) and run the mediator:
+Next, you can open a new terminal window (not one inside of the devcontainer) and run the mediator. Replace `foo.com` below with `localhost` if you are using this locally or some sort of proxy like ngrok if you want external access:
 
 ```console
-docker run -it --rm -p 3001:3001 afj-mediator
+docker run -it --rm -e AGENT_ENDPOINTS="http://foo.com:3001,ws://foo.com:3001" -p 3001:3001 afj-mediator
 ```
 
 At this point you should have a running mediator in AFJ.


### PR DESCRIPTION
Small change to docs to demonstrate how to override the URL the mediator uses to create the invitation.