### PR TITLE
fix: parameterize node version

### DIFF
--- a/afj/Dockerfile
+++ b/afj/Dockerfile
@@ -3,6 +3,8 @@ FROM ghcr.io/findy-network/findy-base:indy-1.16.ubuntu-18.04 AS indy-base
 
 FROM ubuntu:18.04
 
+ARG NODE_VERSION=v16.20.0
+
 # install indy deps and files from base
 RUN apt-get update && apt-get install -y libsodium23 libssl1.1 libzmq5 git zsh
 
@@ -14,10 +16,10 @@ RUN apt-get install -y curl python3 build-essential ca-certificates && \
   curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash && \
   export NVM_DIR="$HOME/.nvm" && \
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
-  nvm install v16 && \
+  nvm install ${NODE_VERSION} && \
   npm install yarn -g
 
-ENV PATH $PATH:/root/.nvm/versions/node/v16.19.1/bin
+ENV PATH $PATH:/root/.nvm/versions/node/${NODE_VERSION}/bin
 
 RUN mkdir /mediator
 


### PR DESCRIPTION
Allow the node version to be passed in as an argument for better customization.