### PR TITLE
chore: proposed update to maintainer list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,16 +4,18 @@
 
 <!-- Please keep this sorted alphabetically by github -->
 
-| Name           | Github | LFID |
-| -------------- | ------ | ---- |
-| Ian Costanzo   | ianco  |      |
-| Jason C. Leach | jleach |      |
+| Name           | Github             | LFID |
+| -------------- | ------             | ---- |
+| Daniel Bluhm   | dbluhm             |      |
+| Jamie Hale     | jamshale           |      |
+| Jason Syrotuck | jsyro              |      |
+| Wade Barnes    | WadeBarnes         |      |
 
 ## Emeritus Maintainers
 
-| Name | Github | LFID |
-| ---- | ------ | ---- |
-|      |        |      |
+| Name           | Github | LFID |
+| -------------- | ------ | ---- |
+| Ian Costanzo   | ianco  |      |
 
 ## Becoming a Maintainer
 


### PR DESCRIPTION
Proposing new list of maintainers for the project:

- promoting @ianco to "emeritus": he is not actively working on the project, but has lots of experience and background on the topic (in addition to having set-up the initial revision)
- @dbluhm has experience with mediator services and it makes sense to have his know-how as a maintainer
- @jamshale and @Jsyro have both contributed plugin code to the repository
- @WadeBarnes because of previous contributions and knowledge running mediators
- retiring @jleach as he is (currently) not actively reviewing new code due to competing priorities

I would ask the people tagged to please comment/👍🏻 and bring up objections/recommendations if there are any. Hoping to get the maintainer list updated soon so we can get the current PRs reviewed/merged before they become stale.