### PR TITLE
Update redis-pq-demo to use playground examples container

### DIFF
--- a/redis-pq-demo/README.md
+++ b/redis-pq-demo/README.md
@@ -7,9 +7,9 @@ How to see a full fledged demo, and a set of agents using the mediator (with red
 To run a redis-cluster and acapy as a mediator with redis for the first time. use the following commands
 
 ```
-git clone https://github.com/hyperledger/aries-mediator-service.git z
-cd redis-pq-demo
-cp .\.env.sample .\.env 
+git clone https://github.com/hyperledger/aries-mediator-service.git
+cd aries-mediator-service/redis-pq-demo
+cp .env.sample .env 
 docker-compose -f docker-compose.redis.yml up -d
 docker-compose up --build
 ```
@@ -18,20 +18,20 @@ After establishing a connection with the mediator. You can inspect the contents 
 
 ## Example agents
 
-If you want to run a set of agents using the mediator, consider the acapy playground demo. 
+If you want to run a set of agents using the mediator, consider the acapy [playground](https://github.com/hyperledger/aries-cloudagent-python/tree/f7db243430285edeb721f079ff0694bb76f41a3e/demo/playground) demo. 
 
 ```
 git clone https://github.com/hyperledger/aries-cloudagent-python.git
 cd aries-cloudagent-python/demo/playground
 cp .env.sample .env
-APP_NETWORK_NAME=redis-cluster docker-compose up
+APP_NETWORK_NAME=redis_cluster APP_NETWORK_EXTERNAL=true docker-compose up --build
 ```
 
-There is a python script provided that will connect all the playground's agents using the provided invitation. Retrieve the invitiation url from the start-up logs of the mediator, and use that for MEDIATOR_INVITATION_URL in the following commands. 
+Along with the playground, there are [examples/tests](https://github.com/hyperledger/aries-cloudagent-python/tree/f7db243430285edeb721f079ff0694bb76f41a3e/demo/playground/examples) that illustrate connecting agents through the mediator and pinging each other. Retrieve the invitiation url from the start-up logs of the mediator, and use that for MEDIATOR_INVITATION_URL in the following commands. 
 
 ```
-cd scripts
-pip install -r requirements.txt
-<edit the MEDIATOR_INVITATION_URL in mediator_ping_agents.py>
-python ./mediator_ping_agents.py
+<new terminal at aries-cloudagent-python/demo/playground>
+cd examples
+docker compose build
+APP_NETWORK_NAME=redis_cluster docker compose run -e MEDIATOR_INVITATION_URL=https://cd55-207-6-152-178.ngrok.io?c_i=eyJAdHlwZSI6ICJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMC9pbnZpdGF0aW9uIiwgIkBpZCI6ICI4ODI4ZDU4Ni0wMDYzLTRkZDktOTQxNy0wNzJhMGE4NDU0MjIiLCAic2VydmljZUVuZHBvaW50IjogImh0dHBzOi8vY2Q1NS0yMDctNi0xNTItMTc4Lm5ncm9rLmlvIiwgInJlY2lwaWVudEtleXMiOiBbIkYxdThXc1JkN2V5VEx6YTFzdEpubmpzeFl3eEwxTW1kWmVMdGdQUEppSmdhIl0sICJsYWJlbCI6ICJNZWRpYXRvciJ9 tests -s
 ```


### PR DESCRIPTION
See [aries-cloudagent-python issue 2555](https://github.com/hyperledger/aries-cloudagent-python/issues/2555)...

Update documentation for redis-pq-demo to use the changes in ACA-Py playground demo.

Fixes #104 