### PR TITLE
Update the requirements for the firebase plugin

### DIFF
--- a/acapy/Dockerfile.acapy
+++ b/acapy/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.9.0
+FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.10.4
 
 USER root
 

--- a/acapy/plugins/firebase_push_notifications/requirements.txt
+++ b/acapy/plugins/firebase_push_notifications/requirements.txt
@@ -1,5 +1,5 @@
-aries-cloudagent==0.9.0
-marshmallow~=3.19.0
+aries-cloudagent>=0.9.0,<1.0.0
+marshmallow~=3.20.1
 google-auth~=2.22.0
 google-api-python-client~=2.94.0
 requests~=2.31.0

--- a/acapy/plugins/firebase_push_notifications/setup.py
+++ b/acapy/plugins/firebase_push_notifications/setup.py
@@ -21,5 +21,5 @@ if __name__ == "__main__":
         packages=find_packages(),
         include_package_data=True,
         install_requires=parse_requirements("requirements.txt"),
-        python_requires=">=3.6.3",
+        python_requires=">=3.9.16",
     )


### PR DESCRIPTION
- Update the requirements so ACA-Py does not get downgraded to meet the requirements set by the plugin.
- Two requirements were causing ACA-Py to be downgraded.
  - The `aries-cloudagent` requirement - The obvious one.
  - The `marshmallow` requirement - The not so obvious one.