### PR TITLE
Additional firebase plugin dependency updates.

### DIFF
--- a/acapy/plugins/firebase_push_notifications/requirements.txt
+++ b/acapy/plugins/firebase_push_notifications/requirements.txt
@@ -1,5 +1,5 @@
 aries-cloudagent>=0.9.0,<1.0.0
 marshmallow~=3.20.1
-google-auth~=2.22.0
-google-api-python-client~=2.94.0
+google-auth~=2.25.2
+google-api-python-client~=2.111.0
 requests~=2.31.0


### PR DESCRIPTION
- Upgrade the google packages to stop urllib3 from being downgraded.
  - Was getting downgraded from 2.0.6 to 1.26.18.