### PR TITLE
chore: set max send rate minutes to zero

### DIFF
--- a/acapy/plugins/firebase_push_notifications/firebase_push_notifications/v1_0/constants.py
+++ b/acapy/plugins/firebase_push_notifications/firebase_push_notifications/v1_0/constants.py
@@ -8,4 +8,4 @@ ENDPOINT_PREFIX = 'v1/projects/'
 ENDPOINT_SUFFIX = '/messages:send'
 
 """Config"""
-MAX_SEND_RATE_MINUTES = 2
+MAX_SEND_RATE_MINUTES = 0


### PR DESCRIPTION
This prevents there from being missed notifications if they are sent immediately after push notifications are enabled in the wallet