### PR TITLE
feat: add device platform to SetDeviceInfo message

### DIFF
--- a/acapy/plugins/firebase_push_notifications/firebase_push_notifications/v1_0/handlers/handler.py
+++ b/acapy/plugins/firebase_push_notifications/firebase_push_notifications/v1_0/handlers/handler.py
@@ -22,7 +22,8 @@ class SetDeviceInfoHandler(BaseHandler):
         assert isinstance(context.message, SetDeviceInfo)
 
         device_token = context.message.device_token
+        device_platform = context.message.device_platform
 
         await save_device_token(context.profile, device_token, connection_id)
 
-        await responder.send_reply(SetDeviceInfo(device_token=device_token))
+        await responder.send_reply(SetDeviceInfo(device_token=device_token, device_platform=device_platform))

--- a/acapy/plugins/firebase_push_notifications/firebase_push_notifications/v1_0/messages/set_device_info.py
+++ b/acapy/plugins/firebase_push_notifications/firebase_push_notifications/v1_0/messages/set_device_info.py
@@ -22,10 +22,12 @@ class SetDeviceInfo(AgentMessage):
         self,
         *,
         device_token: str = None,
+        device_platform: str = "Unknown",
         **kwargs
     ):
         super().__init__(**kwargs)
         self.device_token = device_token
+        self.device_platform = device_platform
 
 
 class SetDeviceInfoSchema(AgentMessageSchema):
@@ -38,4 +40,10 @@ class SetDeviceInfoSchema(AgentMessageSchema):
         required=True,
         description="Firebase device token",
         example="kMCFR-6R6GTfH_XeuXy5v:APA91bHqZgXLV3VtxOxXGy1Sq14_jU5Yhnhc6kTDlF2At3IcuxNK1_kmjak9_f2WAJ8bJHV2GSJj6DBT60j_BqrdTOi9sXIcWEtSBNiJ1vyr9BG0IEsmDuqO4jkIDGNbe2kU_LZf8Q24"
+    )
+
+    device_platform = fields.Str(
+        required=True,
+        description="Platform of the device",
+        example="Android"
     )


### PR DESCRIPTION
This pull request adds the `device_platform` field to the `SetDeviceInfo` message. Previously, the message only contained the `device_token` field. With this change, the `device_platform` field allows for specifying the platform of the device. This enhancement improves the flexibility and functionality of the `SetDeviceInfo` message.